### PR TITLE
Fix unit tests for search filtering and recommendation

### DIFF
--- a/CSCN71030_Tests/CSCN71030_Tests.cpp
+++ b/CSCN71030_Tests/CSCN71030_Tests.cpp
@@ -133,12 +133,12 @@ namespace RecommendationTests
 			freeRecommendations(results);
 		}
 
-		TEST_METHOD(GenerateRecommendations_SortsByPrice)
+		TEST_METHOD(GenerateRecommendations_SortByRating_ThenPrice)
 		{
 			Facility filteredItems[3] = {
 				{1, "Hotel A", "hotel", 200.0f, 4.5f, 1, 1},
-				{2, "Hotel B", "hotel", 100.0f, 4.0f, 1, 0},
-				{3, "Hotel C", "hotel", 150.0f, 3.5f, 0, 1}
+				{2, "Hotel B", "hotel", 100.0f, 4.5f, 1, 0},
+				{3, "Hotel C", "hotel", 150.0f, 4.0f, 0, 1}
 			};
 
 			int recommendationCount = 0;
@@ -147,9 +147,15 @@ namespace RecommendationTests
 
 			Assert::IsNotNull(results);
 			Assert::AreEqual(3, recommendationCount);
-			Assert::AreEqual(100.0f, results[0].price);
-			Assert::AreEqual(150.0f, results[1].price);
-			Assert::AreEqual(200.0f, results[2].price);
+
+			// Highest rating first
+			Assert::AreEqual(4.5f, results[0].rating);
+			Assert::AreEqual(100.0f, results[0].price); // lower price first
+
+			Assert::AreEqual(4.5f, results[1].rating);
+			Assert::AreEqual(200.0f, results[1].price);
+
+			Assert::AreEqual(4.0f, results[2].rating);
 
 			freeRecommendations(results);
 		}

--- a/CSCN71030_Tests/CSCN71030_Tests.cpp
+++ b/CSCN71030_Tests/CSCN71030_Tests.cpp
@@ -105,7 +105,7 @@ namespace RecommendationTests
 
 		// empty input
 
-		TEST_METHOD(GenerateRecommenedations_EmptyInput_ReturnsNull)
+		TEST_METHOD(GenerateRecommendations_EmptyInput_ReturnsNull)
 		{
 			Facility* filteredItems = NULL;
 			int recommendationCount = 0;
@@ -120,7 +120,8 @@ namespace RecommendationTests
 		TEST_METHOD(GenerateRecommendations_SingleMatchingResult)
 		{
 			Facility filteredItems[1] = {
-				{1, "Hotel A", "hotel", 100.0f, 4.5f} };
+				{1, "Hotel A", "hotel", 100.0f, 4.5f, 1, 1} 
+			};
 
 			int recommendationCount = 0;
 
@@ -132,7 +133,26 @@ namespace RecommendationTests
 			freeRecommendations(results);
 		}
 
-		// check sorting by rating (highest first)
+		TEST_METHOD(GenerateRecommendations_SortsByPrice)
+		{
+			Facility filteredItems[3] = {
+				{1, "Hotel A", "hotel", 200.0f, 4.5f, 1, 1},
+				{2, "Hotel B", "hotel", 100.0f, 4.0f, 1, 0},
+				{3, "Hotel C", "hotel", 150.0f, 3.5f, 0, 1}
+			};
+
+			int recommendationCount = 0;
+
+			Facility* results = generateRecommendations(filteredItems, 3, &recommendationCount);
+
+			Assert::IsNotNull(results);
+			Assert::AreEqual(3, recommendationCount);
+			Assert::AreEqual(100.0f, results[0].price);
+			Assert::AreEqual(150.0f, results[1].price);
+			Assert::AreEqual(200.0f, results[2].price);
+
+			freeRecommendations(results);
+		}
 
 	};
 }

--- a/CSCN71030_Tests/CSCN71030_Tests.cpp
+++ b/CSCN71030_Tests/CSCN71030_Tests.cpp
@@ -63,6 +63,20 @@ namespace SearchFilteringTests
 			Assert::IsNull(result);
 			Assert::AreEqual(0, filteredCount);
 		}
+
+		TEST_METHOD(FilterByBudget_CategoryMismatch_NoResults)
+		{
+			Facility items[2] = {
+				{1, "Hotel A", "hotel", 100.0f, 4.5f, 1, 1},
+				{2, "Hotel B", "hotel", 150.0f, 4.0f, 1, 0}
+			};
+
+			int filteredCount = 0;
+			Facility* result = filterByBudget(items, 2, "gym", 0.0f, 200.0f, &filteredCount);
+
+			Assert::IsNull(result);
+			Assert::AreEqual(0, filteredCount);
+		}
 	};
 }
 


### PR DESCRIPTION
This PR fixes and improves unit tests for search filtering and recommendation modules.

Changes:
- Added test for category mismatch
- Added recommendation unit tests
- Fixed sorting test (rating first, then price)

All tests are now passing correctly.